### PR TITLE
Add docstrings to data prep and training functions

### DIFF
--- a/src/data_prep.py
+++ b/src/data_prep.py
@@ -16,6 +16,16 @@ from src.utils import map_dataset, _first, _as_str
 from typing import Optional, Union
 
 def load_dataset_hf(dataset_name: str, sample_len: Optional[int] = None) -> Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]:
+    """
+    Carrega um dataset do Hugging Face.
+
+    Parâmetros:
+        dataset_name (str): Nome do dataset.
+        sample_len (int, opcional): Quantidade de exemplos a carregar.
+
+    Retorna:
+        Union[Dataset, DatasetDict, IterableDataset, IterableDatasetDict]: Dataset carregado.
+    """
     return load_dataset(dataset_name, split=f"train[:{sample_len}]" if sample_len is not None else "train")
 
 def _norm_space(s: str) -> str:
@@ -48,10 +58,20 @@ def _clean(s):
     return s
 
 def build_sciq_answer(ca, sup):
+    """
+    Constrói a resposta do SciQ combinando a resposta correta e o suporte.
+
+    Parâmetros:
+        ca: Resposta correta.
+        sup: Texto de suporte.
+
+    Retorna:
+        str: Resposta final normalizada.
+    """
     ca, sup = _clean(ca), _clean(sup)
-    if not ca: 
+    if not ca:
         return sup
-    if not sup: 
+    if not sup:
         return ca
     # evita duplicar se sup já começa com a resposta
     if sup.lower().startswith(ca.lower()):
@@ -59,6 +79,15 @@ def build_sciq_answer(ca, sup):
     return f"{ca}. {sup}"
 
 def extract_answer_from_annotations(annotations: dict) -> str:
+    """
+    Extrai a "short answer" das anotações do dataset Natural Questions.
+
+    Parâmetros:
+        annotations (dict): Estrutura de anotações fornecida pelo dataset.
+
+    Retorna:
+        str: Resposta normalizada ou string vazia.
+    """
     if not annotations:
         return ""
 
@@ -99,6 +128,16 @@ def nq_to_dialog(example):
 
 
 def to_dialog(example, src):
+    """
+    Converte exemplos de diferentes fontes para o formato comum de diálogo.
+
+    Parâmetros:
+        example: Registro original do dataset.
+        src (str): Nome da fonte ("alpaca", "dolly", "sciq" ou "natural-questions").
+
+    Retorna:
+        dict: Dicionário com a chave "dialogue".
+    """
     if src == "alpaca":
         return {"dialogue":[
             {"role":"user","content":example["instruction"] + ("" if not example["input"] else " " + example["input"])},
@@ -115,11 +154,20 @@ def to_dialog(example, src):
             {"role":"user","content": _clean(example["question"])},
             {"role":"assistant","content": answer}
         ]}
-
     elif src == "natural-questions":
         return nq_to_dialog(example)
-    
+
 def add_source_column(ds, source_name: str) -> Dataset:
+    """
+    Adiciona uma coluna "source" com o nome da origem do exemplo.
+
+    Parâmetros:
+        ds (Dataset): Dataset original.
+        source_name (str): Nome da fonte.
+
+    Retorna:
+        Dataset: Dataset com a coluna adicionada.
+    """
     return ds.map(lambda _: {"source": source_name})
 
 
@@ -128,6 +176,17 @@ def _take(ds: Dataset, n: int, seed: int = 42) -> Dataset:
     return ds.shuffle(seed=seed).select(range(n))
 
 def balance_by_targets(dsets: dict, targets: dict, seed: int = 42) -> Dataset:
+    """
+    Balanceia múltiplos datasets conforme tamanhos-alvo.
+
+    Parâmetros:
+        dsets (dict): Mapeamento nome -> dataset.
+        targets (dict): Quantidade desejada de exemplos por dataset.
+        seed (int): Semente para embaralhamento.
+
+    Retorna:
+        Dataset: Dataset combinado e balanceado.
+    """
     balanced = []
     for name, ds in dsets.items():
         ds = add_source_column(ds, name)
@@ -138,12 +197,34 @@ def balance_by_targets(dsets: dict, targets: dict, seed: int = 42) -> Dataset:
     return concatenate_datasets(balanced).shuffle(seed=seed)
 
 def split_keep_ratios(ds: Dataset, val: float = 0.02, test: float = 0.02, seed: int = 42) -> DatasetDict:
+    """
+    Divide um dataset em subconjuntos mantendo as proporções desejadas.
+
+    Parâmetros:
+        ds (Dataset): Dataset completo.
+        val (float): Fração destinada à validação.
+        test (float): Fração destinada ao teste.
+        seed (int): Semente de aleatoriedade.
+
+    Retorna:
+        DatasetDict: Partições "train", "val" e "test".
+    """
     tmp_size = val + test
     spl1 = ds.train_test_split(test_size=tmp_size, seed=seed)
     tmp  = spl1["test"].train_test_split(test_size=test/(val + test), seed=seed)
     return DatasetDict({"train": spl1["train"], "val": tmp["train"], "test": tmp["test"]})
 
 def convert_dataset(dataset, name):
+    """
+    Converte um dataset de origem específica para conter apenas a coluna "dialogue".
+
+    Parâmetros:
+        dataset (Dataset): Dataset de entrada.
+        name (str): Identificador da origem para escolha da conversão.
+
+    Retorna:
+        Dataset: Dataset com apenas a coluna "dialogue".
+    """
     # Remove todas as colunas originais e mantém apenas a coluna 'dialogue' criada pelo mapeamento
     mapped = dataset.map(lambda ex: to_dialog(ex, name))
     keep = ["dialogue"]
@@ -152,10 +233,22 @@ def convert_dataset(dataset, name):
 
 
 def split_dataset(dataset, val_size=0.025, test_size=0.025, seed=42):
+    """
+    Realiza divisão simples de um dataset em treino, validação e teste.
+
+    Parâmetros:
+        dataset (Dataset): Dataset completo.
+        val_size (float): Fração para validação.
+        test_size (float): Fração para teste.
+        seed (int): Semente de aleatoriedade.
+
+    Retorna:
+        dict: Dicionário com chaves "train", "val" e "test".
+    """
     # Separa dataset em train e val+test
     temp_size = val_size + test_size
     split1 = dataset.train_test_split(test_size=temp_size, seed=seed)
-    
+
     train_ds = split1["train"]
     temp_ds = split1["test"]
 
@@ -169,11 +262,34 @@ def split_dataset(dataset, val_size=0.025, test_size=0.025, seed=42):
     return {"train": train_ds, "val": val_ds, "test": test_ds}
 
 def concatenate_datasets_(datasets, val_size=.025, test_size=.025, seed=42, force_ascii=False):
+    """
+    Concatena uma lista de datasets e grava versão bruta em disco.
+
+    Parâmetros:
+        datasets (list[Dataset]): Lista de datasets.
+        val_size (float): Fração para validação.
+        test_size (float): Fração para teste.
+        seed (int): Semente para embaralhamento.
+        force_ascii (bool): Força codificação ASCII ao salvar JSONL.
+
+    Retorna:
+        dict: Splits "train", "val" e "test" resultantes.
+    """
     full = concatenate_datasets(datasets)
     full.shuffle(seed=seed).to_json("../data/raw/train_edu.jsonl", lines=True, force_ascii=force_ascii)
     return split_dataset(full, val_size=val_size, test_size=test_size, seed=seed)
 
 def filter_dataset(dataset, column):
+    """
+    Remove exemplos com conteúdo vazio em determinada coluna.
+
+    Parâmetros:
+        dataset (Dataset): Dataset a ser filtrado.
+        column (str): Coluna a ser inspecionada.
+
+    Retorna:
+        Dataset: Dataset filtrado.
+    """
     return dataset.filter(lambda ex: len(ex[column]) > 0)
 
 def _ensure_text(x):
@@ -185,6 +301,15 @@ def _ensure_text(x):
 
 
 def strip_html_safe(s: str) -> str:
+    """
+    Remove tags HTML de maneira tolerante a erros de parsing.
+
+    Parâmetros:
+        s (str): Texto potencialmente contendo HTML.
+
+    Retorna:
+        str: Texto sem marcações HTML.
+    """
     # tolerant parser
     try:
         return BeautifulSoup(s, "html.parser").get_text(" ", strip=True)
@@ -193,6 +318,15 @@ def strip_html_safe(s: str) -> str:
         return re.sub(r"<[^>]+>", " ", s or "")
 
 def clean_text(text):
+    """
+    Limpa texto removendo HTML, caracteres de controle e espaços extras.
+
+    Parâmetros:
+        text: Texto de entrada.
+
+    Retorna:
+        str: Texto normalizado.
+    """
     text = _ensure_text(text)
     text = re.sub(r"[\x00-\x08\x0B-\x0C\x0E-\x1F]", " ", text)  # remove control chars
     text = strip_html_safe(text)
@@ -202,6 +336,15 @@ def clean_text(text):
 
 
 def clean_dialogue(example):
+    """
+    Limpa e normaliza as mensagens de um diálogo.
+
+    Parâmetros:
+        example (dict): Exemplo contendo a chave "dialogue".
+
+    Retorna:
+        dict: Dicionário com a chave "dialogue" limpa.
+    """
     cleaned_dialogue = []
     for msg in example.get("dialogue", []):
         role = _ensure_text(msg.get("role", "")).strip().lower()
@@ -214,6 +357,15 @@ def clean_dialogue(example):
     return {"dialogue": cleaned_dialogue} if cleaned_dialogue else {"dialogue": []}
 
 def clean_dataset(dataset):
+    """
+    Aplica `clean_dialogue` em todas as partições do dataset.
+
+    Parâmetros:
+        dataset (dict): Dicionário com splits "train", "val" e "test".
+
+    Retorna:
+        dict: Estrutura com diálogos limpos em todas as partições.
+    """
     splits = {
         "train": map_dataset(dataset["train"], clean_dialogue),
         "val": map_dataset(dataset["val"], clean_dialogue),
@@ -224,7 +376,7 @@ def clean_dataset(dataset):
         splits[k] = splits[k].filter(
             lambda ex: isinstance(ex.get("dialogue"), list) and any(m.get("content") for m in ex["dialogue"])
         )
-        
+
     return splits
 
 def save_text_jsonl(data, fname):

--- a/src/train_loop.py
+++ b/src/train_loop.py
@@ -31,6 +31,20 @@ if logging_args.get("report_to", "none") == "wandb":
 
 
 def create_trainer(model, dataset, tokenizer):
+    """
+    Configura o `Trainer` do Hugging Face com parâmetros do projeto.
+
+    Parâmetros:
+        model: Modelo a ser treinado.
+        dataset (dict): Datasets com chaves ``train`` e ``val``.
+        tokenizer: Tokenizer usado para preparar os lotes.
+
+    Retorna:
+        Trainer: Instância pronta para o treinamento.
+
+    Efeitos colaterais:
+        Cria diretório de saída em ``../experiments``.
+    """
     out_dir = Path("../experiments") / f"{project_name}" / f"seed{seed}"
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -113,7 +127,20 @@ def create_trainer(model, dataset, tokenizer):
     )
 
 def train(model, dataset, tokenizer):
+    """
+    Executa o ciclo de treinamento completo.
 
+    Parâmetros:
+        model: Modelo base a ser treinado.
+        dataset (dict): Datasets contendo splits de treino e validação.
+        tokenizer: Tokenizer associado ao modelo.
+
+    Retorna:
+        Trainer: ``Trainer`` após o término do treinamento.
+
+    Efeitos colaterais:
+        Atualiza configurações do W&B e salva o estado do ``Trainer``.
+    """
     if logging_args.get("report_to", "none") == "wandb":
         wandb.config.update(params, allow_val_change=True)
     trainer = create_trainer(model, dataset, tokenizer)
@@ -121,10 +148,34 @@ def train(model, dataset, tokenizer):
     trainer.save_state()
     return trainer
 
+
 def evaluate(trainer):
+    """
+    Avalia o modelo no conjunto de validação.
+
+    Parâmetros:
+        trainer (Trainer): Instância já treinada.
+
+    Retorna:
+        dict: Métricas de avaliação.
+    """
     return trainer.evaluate()
 
+
 def save_model_tokenizer(trainer, tokenizer):
+    """
+    Salva o modelo ajustado e o tokenizer no diretório de experimentos.
+
+    Parâmetros:
+        trainer (Trainer): Objeto contendo o modelo treinado.
+        tokenizer: Tokenizer a ser persistido.
+
+    Retorna:
+        None
+
+    Efeitos colaterais:
+        Cria diretório e grava arquivos de modelo e tokenizer.
+    """
     # Salva adapters (como o Trainer já está sobre PeftModel, isso grava os pesos do adapter)
     #out = "..//experiments/checkpoints/adapter"
     out = Path("../experiments") / f"{project_name}" / f"seed{seed}"


### PR DESCRIPTION
## Summary
- document dataset utilities in `data_prep.py`
- document training helpers in `train_loop.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5e6f44d0832e9d3c5fc51c143596