### PR TITLE
Use filename in missing config error

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,7 @@ def load_params(filename):
 
         return config_params
     except FileNotFoundError:
-        print("Error: config.yaml not found.")
+        print(f"Error: {filename} not found.")
     except yaml.YAMLError as e:
         print(f"Error parsing YAML file: {e}")
 


### PR DESCRIPTION
## Summary
- reference provided filename in `load_params` FileNotFoundError message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5910a3e4832eae7d3d279ec6332f