### PR TITLE
docs: fix comment in annotation parsing

### DIFF
--- a/src/data_prep.py
+++ b/src/data_prep.py
@@ -69,7 +69,7 @@ def extract_answer_from_annotations(annotations: dict) -> str:
     sa = annotations.get("short_answers")
     if isinstance(sa, list) and len(sa) > 0:
         sa0 = sa[0]
-        # 'text' pode ser str, lista de str, lista de lista...
+        # 'text' pode ser str, lista de str, lista de listas...
         txt = sa0.get("text")
         txt = _as_str(txt)        # desempacota iterativamente
         if isinstance(txt, str) and txt.strip():


### PR DESCRIPTION
## Summary
- fix `_extract_answer_from_annotations` comment to say "lista de listas"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5777d850832e93567502c44a97c6