### PR TITLE
Increase generated token limit to avoid truncated chat responses

### DIFF
--- a/scripts/04_chat.py
+++ b/scripts/04_chat.py
@@ -78,7 +78,8 @@ while True:
     with torch.no_grad():
         out_ids = model.generate(
             **inputs,
-            max_new_tokens=64,                # menor → menos “rabo”
+            # aumenta o limite para evitar cortes abruptos em respostas longas
+            max_new_tokens=128,
             repetition_penalty=1.15,
             no_repeat_ngram_size=3,
             bad_words_ids=bad_words_ids,


### PR DESCRIPTION
## Summary
- Increase `max_new_tokens` in chat script to prevent responses from being cut mid-sentence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa81c1bfc832eb0a3a7f98f6c9390