### PR TITLE
Increase generated token limit to avoid truncated chat responses

### DIFF
--- a/scripts/04_chat.py
+++ b/scripts/04_chat.py
@@ -78,7 +78,8 @@ while True:
     with torch.no_grad():
         out_ids = model.generate(
             **inputs,
-            max_new_tokens=64,                # menor → menos “rabo”
+            # aumenta o limite para evitar cortes abruptos em respostas longas
+            max_new_tokens=128,
             repetition_penalty=1.15,
             no_repeat_ngram_size=3,
             bad_words_ids=bad_words_ids,

--- a/src/inference_loop.py
+++ b/src/inference_loop.py
@@ -127,7 +127,8 @@ def _postprocess_response(tokenizer, prompt_ids, full_ids):
 @torch.no_grad()
 def chat(
     model, tokenizer, user_text: str,
-    max_new_tokens=48, temperature=0.5, top_p=0.9,
+    # aumenta o limite padrão para evitar cortes abruptos em respostas longas
+    max_new_tokens=128, temperature=0.5, top_p=0.9,
     repetition_penalty=1.12, do_sample=True, **gen_kwargs
 ):
     # limpar duplicatas


### PR DESCRIPTION
## Summary
- Raise default generation window in `chat` utility to 128 tokens, matching interactive script and preventing early cutoffs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fa81c1bfc832eb0a3a7f98f6c9390